### PR TITLE
Allow callable as gauges

### DIFF
--- a/metrology/instruments/gauge.py
+++ b/metrology/instruments/gauge.py
@@ -16,6 +16,9 @@ class Gauge(object):
       gauge = Metrology.gauge('pending-jobs', JobGauge())
 
     """
+    def __call__(self, *args, **kwargs):
+        return self.value
+
     @property
     def value(self):
         """"""


### PR DESCRIPTION
Allow to use a simple callable as a gauge. 
