### PR TITLE
Py3 compatibility for plaintext Graphite reporter

### DIFF
--- a/metrology/reporter/graphite.py
+++ b/metrology/reporter/graphite.py
@@ -2,6 +2,7 @@ import re
 import socket
 import pickle
 import struct
+import sys
 
 from metrology.instruments import *  # noqa
 from metrology.reporter.base import Reporter

--- a/metrology/reporter/graphite.py
+++ b/metrology/reporter/graphite.py
@@ -126,7 +126,10 @@ class GraphiteReporter(Reporter):
 
     def _send_plaintext(self):
         if len(self.batch_buffer):
-            self.socket.sendall(self.batch_buffer + "\n")
+            if sys.version_info[0] > 2:           
+                self.socket.sendall(bytes(self.batch_buffer + '\n', 'ascii'))
+            else:                                              
+                self.socket.sendall(self.batch_buffer + "\n")
             # Reinitialze buffer and counter
             self.batch_count = 0
             self.batch_buffer = ""


### PR DESCRIPTION
In Python 3 you need to send bytes instead string through sendall function. Check takes about 150ns and make this part of code compatible with new version of Python.