### PR TITLE
Allow to use timer and meter as decorators and with context manager

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,21 @@ In addition to the mean rate, you can also track 1, 5 and 15 minutes moving aver
     meter.mark()
     meter.count
 
+or as a decorator:
+
+.. code-block:: python
+
+    @Metrology.meter('requests')
+    def do_this_again():
+        # do something
+
+or with context manager:
+
+.. code-block:: python
+
+    with Metrology.meter('requests'):
+        # do something
+
 Timers
 ------
 
@@ -63,6 +78,14 @@ A timer measures both the rate that a particular piece of code is called and the
     timer = Metrology.timer('responses')
     with timer:
         do_something()
+
+or as a decorator:
+
+.. code-block:: python
+
+    @Metrology.timer('responses')
+    def response():
+        # do_something
 
 
 Utilization Timer

--- a/metrology/instruments/meter.py
+++ b/metrology/instruments/meter.py
@@ -43,6 +43,20 @@ class Meter(object):
             for _ in range(ticks):
                 self.tick()
 
+    def __call__(self, *args, **kwargs):
+        if args and hasattr(args[0], '__call__'):
+            _orig_func = args[0]
+            def _decorator(*args, **kwargs):
+                with self:
+                    _orig_func(*args, **kwargs)
+            return _decorator
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc, exv, trace):
+        self.mark()
+
     @property
     def count(self):
         """Returns the total number of events that have been recorded."""

--- a/metrology/instruments/timer.py
+++ b/metrology/instruments/timer.py
@@ -17,6 +17,14 @@ class Timer(object):
         self.meter = Meter()
         self.histogram = histogram()
 
+    def __call__(self, *args, **kwargs):
+        if args and hasattr(args[0], '__call__'):
+            _orig_func = args[0]
+            def _decorator(*args, **kwargs):
+                with self:
+                    _orig_func(*args, **kwargs)
+            return _decorator
+
     def clear(self):
         self.meter.clear()
         self.histogram.clear()

--- a/metrology/reporter/base.py
+++ b/metrology/reporter/base.py
@@ -1,3 +1,5 @@
+import atexit
+
 from metrology.registry import registry
 from metrology.utils.periodic import PeriodicTask
 
@@ -6,9 +8,13 @@ class Reporter(PeriodicTask):
     def __init__(self, interval=60, *args, **options):
         self.registry = options.get('registry', registry)
         super(Reporter, self).__init__(interval=interval)
+        atexit.register(self._exit)
 
     def task(self):
         self.write()
 
     def write(self):
         raise NotImplementedError
+
+    def _exit(self):
+        self.write()

--- a/metrology/reporter/graphite.py
+++ b/metrology/reporter/graphite.py
@@ -127,9 +127,9 @@ class GraphiteReporter(Reporter):
 
     def _send_plaintext(self):
         if len(self.batch_buffer):
-            if sys.version_info[0] > 2:           
+            if sys.version_info[0] > 2:
                 self.socket.sendall(bytes(self.batch_buffer + '\n', 'ascii'))
-            else:                                              
+            else:
                 self.socket.sendall(self.batch_buffer + "\n")
             # Reinitialze buffer and counter
             self.batch_count = 0

--- a/tests/instruments/test_meter.py
+++ b/tests/instruments/test_meter.py
@@ -34,5 +34,20 @@ class MeterTest(TestCase):
             thread.join()
         self.assertEqual(1000, self.meter.count)
 
+    def test_meter_decorator(self):
+        @self.meter
+        def _test_decorator():
+            pass
+
+        for i in range (500):
+            _test_decorator()
+        self.assertEqual(500, self.meter.count)
+
+    def test_meter_context_manager(self):
+        for i in range(275):
+            with self.meter:
+                pass
+        self.assertEqual(275, self.meter.count)
+
     def tearDown(self):
         self.meter.stop()

--- a/tests/instruments/test_timer.py
+++ b/tests/instruments/test_timer.py
@@ -19,6 +19,25 @@ class TimerTest(TestCase):
         self.assertAlmostEqual(100, self.timer.mean, delta=10)
         self.assertAlmostEqual(100, self.timer.snapshot.median, delta=10)
 
+    def test_timer_decorator(self):
+        @self.timer
+        def _test_decorator():
+            time.sleep(0.075)
+
+        for i in range(3):
+            _test_decorator()
+
+        self.assertAlmostEqual(75, self.timer.mean, delta=10)
+        self.assertAlmostEqual(75, self.timer.snapshot.median, delta=10)
+
+    def test_timer_context_manager(self):
+        for i in range(3):
+            with self.timer:
+                time.sleep(0.035)
+
+        self.assertAlmostEqual(35, self.timer.mean, delta=10)
+        self.assertAlmostEqual(35, self.timer.snapshot.median, delta=10)
+
 
 class UtilizationTimerTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
Possible usage:
```python
def test_context():
    for i in range(0, 5000):
        with Metrology.meter('meter_context_5000'):
            pass

@Metrology.meter('meter_decorator')
def text_decorator():
    pass
```
This change applies only to **timer** and **meter**